### PR TITLE
Fix bug for creating events when tag is not selected.

### DIFF
--- a/src/app/Http/Controllers/EventController.php
+++ b/src/app/Http/Controllers/EventController.php
@@ -60,7 +60,7 @@ class EventController extends Controller
             $validated['image'] = $request->get('image') ?? $request->all()['image'];
             $event = Event::create($validated);
             // attach tags
-            if ($validated['tags']) {
+            if (!empty($validated['tags'])) {
                 $event->attachTags($validated["tags"]);
             }
             // attach myself as a participant


### PR DESCRIPTION
## Content
As the title says.
## Image

## Related Issue
fixed #155 

## notes
When creating a new or updated event, uploading an image and sending a query with an empty array of values for a specific field was causing an error because the key was not added to the associative array for the specific parameter due to laravel's specifications.
