### PR TITLE
Add mailing function for register user and waiting list

### DIFF
--- a/src/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/src/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
+use App\Mail\RegisteredConfirmationMail;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -46,6 +48,9 @@ class RegisteredUserController extends Controller
         event(new Registered($user));
 
         Auth::login($user);
+
+        // send an email to the user who registered
+        Mail::send(new RegisteredConfirmationMail($request));
 
         return redirect(RouteServiceProvider::HOME);
     }

--- a/src/app/Http/Controllers/EventController.php
+++ b/src/app/Http/Controllers/EventController.php
@@ -77,7 +77,7 @@ class EventController extends Controller
      */
     public function show(Event $event): Response
     {
-        $is_attended = $event->isAttended();
+        $is_attended = $event->isAttended() || $event->isWaitListed();
         $is_hosted = $event->isHosted();
         $host_user = $event->user()->first();
         $participants = $event->participants()->get();

--- a/src/app/Http/Controllers/ParticipantController.php
+++ b/src/app/Http/Controllers/ParticipantController.php
@@ -6,7 +6,8 @@ use App\Models\Event;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\WaitingListAdvanceMail;
 
 class ParticipantController extends Controller
 {
@@ -56,6 +57,9 @@ class ParticipantController extends Controller
             $first_wait_list = $wait_list->first();
             $event->participants()->attach($first_wait_list->user_id);
             $event->waitList()->detach($first_wait_list->user_id);
+
+            // Send an email to users who have moved up from the waiting list
+            Mail::send(new WaitingListAdvanceMail($event, $first_wait_list));
         } else {
             $event->waitList()->detach(auth()->id());
         }

--- a/src/app/Mail/RegisteredConfirmationMail.php
+++ b/src/app/Mail/RegisteredConfirmationMail.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Http\Request;
+use Illuminate\Queue\SerializesModels;
+
+class RegisteredConfirmationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+    * Get the message envelope.
+    *
+    * @return \Illuminate\Mail\Mailables\Envelope
+    */
+    public function envelope()
+    {
+        $envelope = new Envelope();
+
+        return $envelope->subject('Your email address has been registered')
+            // Sender's e-mail address
+            ->from('foo@example.net')
+            ->to($this->request->email);
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        $contact = new Content();
+        return $contact->markdown('emails.registered_confirmation_mail')->with([
+            'name' => $this->request->name,
+            'email' => $this->request->email
+        ]);
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/app/Mail/WaitingListAdvanceMail.php
+++ b/src/app/Mail/WaitingListAdvanceMail.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class WaitingListAdvanceMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /** @var User **/
+    protected $user;
+    /** @var Event **/
+    protected $event;
+
+    /**
+     * Create a new message instance.
+     * @param Event $event
+     * @param User $user
+     * @return void
+     */
+    public function __construct($event, $user)
+    {
+        $this->event = $event;
+        $this->user = $user;
+    }
+
+    /**
+    * Get the message envelope.
+    * @return Envelope
+    */
+    public function envelope(): Envelope
+    {
+        $envelope = new Envelope();
+
+        return $envelope->subject('You were added to a event!')
+            ->from('foo@example.net')
+            ->to($this->user->email);
+    }
+
+    /**
+     * Get the message content definition.
+     * @return Content
+     */
+    public function content(): Content
+    {
+        $contact = new Content();
+        return $contact->markdown('emails.waiting_list_advance_mail')->with([
+            'name' => $this->user->name,
+            'email' => $this->user->email,
+            'event_name' => $this->event->name,
+            'event_start_date' => $this->event->start_date,
+            'event_end_date' => $this->event->end_date,
+            'event' => $this->event,
+        ]);
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/resources/views/emails/registered_confirmation_mail.blade.php
+++ b/src/resources/views/emails/registered_confirmation_mail.blade.php
@@ -1,0 +1,19 @@
+<x-mail::message>
+# Your email address has been registered
+## Dear {{ $name }}
+<br>
+    Your email address has been registered as the following information:
+<br>
+    name: {{ $name }}
+<br>
+    email: {{ $email }}
+<br>
+
+<x-mail::button url="{{ route('events.index') }}">
+    Check events
+</x-mail::button>
+
+Thanks<br>
+
+</x-mail::message>
+

--- a/src/resources/views/emails/waiting_list_advance_mail.blade.php
+++ b/src/resources/views/emails/waiting_list_advance_mail.blade.php
@@ -1,0 +1,20 @@
+<x-mail::message>
+# Great news! You were added a event!:
+## Dear {{ $name }}
+<br>
+    You were added to the following class
+<br>
+    event name: {{ $event_name }}
+<br>
+    start date: {{ $event_start_date }}
+<br>
+    end date: {{ $event_end_date }}
+<br>
+
+<x-mail::button url="{{ route('events.show', ['event' => $event]) }}">
+    Check the event
+</x-mail::button>
+
+Thanks<br>
+
+</x-mail::message>


### PR DESCRIPTION
## Content
As the title says.
## Image
![スクリーンショット 2023-06-27 午後6 25 05](https://github.com/akaka0039/Global_Developer_site/assets/46436794/158a4dc3-414d-43f4-ae76-034b1f8e0cca)

![image](https://github.com/akaka0039/Global_Developer_site/assets/46436794/928bee22-0fc9-44f6-93be-4526c99b3517)

## Related Issue
fixed #99  fixed #169

## notes
Set up to send an email notification when a user completes registration and when they are able to join an event from the waitlist.
In the local environment,[MailTrap](https://mailtrap.io/) can be used to verify that the emails are sent correctly.
